### PR TITLE
Use bundler for Sass dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,15 +79,13 @@ build/Release
 # Dependency directories
 node_modules
 jspm_packages
+bower_components
 
 # Optional npm cache directory
 .npm
 
 # Optional REPL history
 .node_repl_history
-
-# Dependency directories
-bower_components
 
 # Sass Cache
 .sass-cache

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ build/Release
 node_modules
 jspm_packages
 bower_components
+vendor
 
 # Optional npm cache directory
 .npm

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem "sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sass (3.4.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sass
+
+BUNDLED WITH
+   1.11.2

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,7 @@ module.exports = function (grunt) {
                 options: {
                     style: 'expanded',
                     precision: 8,
+                    bundleExec: true,
                     'unix-newlines': true
                 }
             }

--- a/README.md
+++ b/README.md
@@ -34,16 +34,18 @@ You can also import the theme into your styles using SASS.
 
 Development
 ------------
-You must have Node + NPM, Grunt CLI, and Bower installed. 
+You must have Node + NPM, Grunt CLI, Bower, and Ruby + Bundler installed. 
 
 * To install Grunt CLI, run: `npm install -g grunt-cli`
 * To install Bower, run: `npm install -g bower`
+* To install Bundler, run: `gem install bundler`
 
 Once you have those tools installed, clone this repo and run the following commands to install dependencies:
 
 ```
 npm install
 bower install
+bundle install
 ```
 
 Once all of the dependencies are installed, run `grunt build` to build the theme (artifacts will be dropped in `./dist`), or simply `grunt` to start a live reload server for development.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ You can also import the theme into your styles using SASS.
 
 Development
 ------------
-You must have Node and Grunt CLI installed. To install Grunt CLI, run: `npm install -g grunt-cli`. Once you have those tools installed, clone this repo and run the following commands to install dependencies:
+You must have Node + NPM, Grunt CLI, and Bower installed. 
+
+* To install Grunt CLI, run: `npm install -g grunt-cli`
+* To install Bower, run: `npm install -g bower`
+
+Once you have those tools installed, clone this repo and run the following commands to install dependencies:
 
 ```
 npm install


### PR DESCRIPTION
Using bundler:
* Takes care of the gem dependency for this project
* Removes the potential for conflicting sass versions
* Keeps sass (+ it’s dependencies) out of the global gemset

(PR is based off of #3, which is what the first commit is)