### PR TITLE
Add two classes related to displaying the name and CDN of the theme

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -103,3 +103,8 @@ $progress-border-radius:  0 !default;
 
 $close-font-size:   2.125rem !default;
 $close-font-weight: 300 !default;
+
+// Identification ==============================================================
+
+$theme-cdn: 'csh-material-bootstrap';
+$theme-name: 'Material';

--- a/src/csh-material-bootstrap.scss
+++ b/src/csh-material-bootstrap.scss
@@ -734,3 +734,13 @@ input[type="checkbox"],
     }
   }
 }
+
+// Identification ==============================================================
+
+.theme-cdn::after {
+  content: $theme-cdn;
+}
+
+.theme-name::after {
+  content: $theme-name;
+}


### PR DESCRIPTION
Based on a discussion had [here](https://github.com/mxmeinhold/CSHThemeSwitcher/issues/6), I think it'd be a good idea to have CSH web apps display information about the currently used theme. An example would be as such:

```
<p>Theme: <a class="theme-name" href="https://themeswitcher.csh.rit.edu"></a></p>
```

The above could go in the footer of a page, for instance.